### PR TITLE
update shell script to open notebook in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ All services are started using a [Docker Compose file](workshop/docker-compose.y
 
 ```bash
 cd workshop
+# start workshop
 ./geopython-workshop-ctl.sh start
+# display URL and open in default web browser
 ./geopython-workshop-ctl.sh url
 
-# Browse to the resulting URL of running geopython-workshop-ctl.sh url for workshop Jupyter Notebooks
 # Browse to http://127.0.01:5000 for workshop pygeoapi service
 # Browse to http://127.0.01:8001 for workshop pycsw service
 # NB Possibly best if we add a frontend or use docs ("home") as entrypoint

--- a/web/docs/docker.md
+++ b/web/docs/docker.md
@@ -32,6 +32,4 @@ sudo docker run hello-world
 cd ~/geopython-workshop-master/workshop
 ./geopython-workshop-ctl.sh start
 ./geopython-workshop-ctl.sh url
-
-# Note the URL with token, copy/paste into browser
 ```

--- a/web/docs/index.md
+++ b/web/docs/index.md
@@ -57,12 +57,9 @@ unzip master
 cd geopython-workshop-master/workshop
 # start the workshop
 ./geopython-workshop-ctl.sh start
-# check the URL+token
-./geopython-workshop-ctl.sh url
 
-# open browser to resulting URL+token
-# or if on Linux/MacOS, run:
-# ./geopython-workshop-ctl.sh url | xargs open
+# display URL and open in default web browser
+./geopython-workshop-ctl.sh url
 
 # stop workshop
 ./geopython-workshop-ctl.sh stop

--- a/workshop/geopython-workshop-ctl.sh
+++ b/workshop/geopython-workshop-ctl.sh
@@ -16,7 +16,9 @@ elif [ $1 == "stop" ]; then
     docker-compose stop
     docker-compose rm --force
 elif [ $1 == "url" ]; then
-    docker logs geopython-workshop-jupyter 2>&1 | grep "    or http" | sed 's/or //'
+    url=`docker logs geopython-workshop-jupyter 2>&1 | grep "    or http" | sed 's/or //' | xargs`
+    echo $url
+    open $url
 elif [ $1 == "clean" ]; then
     # Remove all exited containers
     for c in $(docker ps -a -f status=exited -q)

--- a/workshop/geopython-workshop-ctl.sh
+++ b/workshop/geopython-workshop-ctl.sh
@@ -16,7 +16,18 @@ elif [ $1 == "stop" ]; then
     docker-compose stop
     docker-compose rm --force
 elif [ $1 == "url" ]; then
-    url=`docker logs geopython-workshop-jupyter 2>&1 | grep "    or http" | sed 's/or //' | xargs`
+    case "$OSTYPE" in
+        cygwin*)
+            alias open="cmd /c start"
+            ;;
+        linux*)
+            alias open="xdg-open"
+            ;;
+        darwin*)
+            alias start="open"
+            ;;
+    esac
+    url=$(docker logs geopython-workshop-jupyter 2>&1 | grep "    or http" | sed 's/or //')
     echo $url
     open $url
 elif [ $1 == "clean" ]; then

--- a/workshop/geopython-workshop-ctl.sh
+++ b/workshop/geopython-workshop-ctl.sh
@@ -16,20 +16,26 @@ elif [ $1 == "stop" ]; then
     docker-compose stop
     docker-compose rm --force
 elif [ $1 == "url" ]; then
-    case "$OSTYPE" in
-        cygwin*)
-            alias open="cmd /c start"
-            ;;
-        linux*)
-            alias open="xdg-open"
-            ;;
-        darwin*)
-            alias start="open"
-            ;;
-    esac
-    url=$(docker logs geopython-workshop-jupyter 2>&1 | grep "    or http" | sed 's/or //')
-    echo $url
-    open $url
+    # try to open the Jupyter Notebook in Browser
+    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+
+    if [[ $platform == 'linux' ]]; then
+       openapp="xdg-open"
+    elif [[ $platform == 'darwin' ]]; then  # MacOS
+       openapp="open"
+    else  # assume some kind of Windows variant
+      openapp="cmd /c start"
+    fi
+
+    url=$(docker logs geopython-workshop-jupyter 2>&1 | grep "    or http" | sed 's/     or //')
+    if [ -z ${url} ]; then
+        echo "workshop not started"
+        echo "did you start the workshop? (i.e. $0 start)"
+        exit 2
+    fi
+    echo "Attempting to open ${url} in your browser on platform ${platform}..."
+    echo "If this fails, simply copy/paste that URL in your browser"
+    ${openapp} ${url}
 elif [ $1 == "clean" ]; then
     # Remove all exited containers
     for c in $(docker ps -a -f status=exited -q)


### PR DESCRIPTION
This PR updates `workshop/geopython-workshop-ctl.sh` so that running `workshop/geopython-workshop-ctl.sh url` will display the URL in the console and then open the URL in a browser.