### PR TITLE
#82 wrap Docker Compose variants in Bash script and add Docker docs

### DIFF
--- a/web/docs/docker.md
+++ b/web/docs/docker.md
@@ -1,36 +1,59 @@
-# Docker installation
+# Docker
 
-## Ubuntu
+## About Docker
 
-There are various install guides for Docker on Ubuntu 20+
-See for example:
+Docker has been available for almost 10 years, and provided as a deployment option on numerous FOSS software and OSGeo projects. Given the current
+era of computing, chances are that you have heard of Docker and *containerization*. Or, perhaps are already familiar and hopefully using Docker already.
+If not, there is a wide array of introductory materials that can be found online like this [tutorial from IBM](https://www.ibm.com/in-en/cloud/learn/Docker).
 
-* https://linuxhint.com/install_configure_docker_ubuntu/
-* https://gdsl-ul.github.io/soft_install
+FOSS4G software has benefitted greatly from Docker (consistent packaging, isolation, integration and upgrade patterns) in
+comparison to custom installations. Though today we mainly use Docker, the bigger picture is the use of **Containers** as a next step
+in virtualization. Containerization certainly deserves its own workshop, so for the purpose of this workshop we cover the basics
+of Docker and Docker Compose.
 
-This comes down to:
+[Docker Compose](https://docs.docker.com/compose) is an addition to Docker to facilitate
+the orchestration (configuration) of one or more Docker 'Containers' (a Container is a running instance of a Docker image)
+using a configuration convention (the Docker Compose YAML file), usually named `docker-compose.yml`.
 
-```
-sudo apt-get update
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt install docker.io
-sudo systemctl enable --now docker 
-# to disable: sudo systemctl disable --now docker
-sudo usermod -a -G docker <your username>
-# Check version
-docker --version
+Stepping up further are even more sophisticated Docker orchestrators like 
+[Rancher](https://rancher.com/products/rancher) and [Kubernetes](https://kubernetes.io), but for
+this workshop, Docker and Docker Compose are all we need.
 
-# Also need Docker Compose
-sudo apt-get install docker-compose
-sudo docker run hello-world
+## Installation
 
-# Restart virtual machine
-# Unpack workshop .zip download (e.g. in your home) from 
-# https://github.com/geopython/geopython-workshop/releases
-# Unpacks in e.g. ~/geopython-workshop-master
+Docker installation has greatly progressed over the years. This is the only part of the workshop
+which is dependent on the system/OS you are running (e.g. Windows, Mac or Linux). For each
+system the Docker website provides detailed installation instructions. 
+Please follow these consistently.
 
-cd ~/geopython-workshop-master/workshop
-./geopython-workshop-ctl.sh start
-./geopython-workshop-ctl.sh url
+> Docker Compose in older (pre Compose v2) versions was a separate (Python) program to install,
+> though it was usually present in Docker Desktop. 
+> The `docker compose` command in that case is `docker-compose` (hyphened).
+> Since 2021, Docker Desktop includes Compose in the Docker CLI.
+> The command is then `docker compose` (space).
+    
+In our texts we will use `docker-compose`. Depending on your installation you may need
+to replace the hyphen (`-`) with a space. But you can always install the original
+compose (`docker-compose`) via `pip install docker-compose`.
+
+For many platforms a product called `Docker Desktop` is available, which includes `Docker Compose`:
+
+* Windows [installation](https://docs.Docker.com/desktop/install/windows-install)
+* Mac [installation](https://docs.Docker.com/desktop/install/mac-install)
+* Linux [installation](https://docs.Docker.com/desktop/install/linux-install)
+
+Some notes:
+
+* On Windows we recommend using the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl) (WSL) as it also provides a powerful (Bash) command line and has optimal integration with Docker
+* On Mac, if you are using [Homebrew](https://brew.sh), consider (as the author has) using the [brew Docker formula](https://formulae.brew.sh/formula/Docker)
+* On Linux, you can choose the relevant installer for your platform. You can also use Virtualbox with a Ubuntu Image or use a cloud VM
+* Docker desktop includes a graphical user interface with some interesting options. You can see logs and information about running containers, open their service in a browser or even open a terminal inside the container
+
+If all goes well, you should be able to run Docker from the command line as follows: [^2]
+
+```bash
+$ docker --version
+Docker version 20.10.17, build 100c701
+$ docker-compose --version  
+Docker Compose version v2.6.1
 ```

--- a/web/docs/index.md
+++ b/web/docs/index.md
@@ -21,7 +21,7 @@ and [pycsw](https://pycsw.org) in this workshop are provided by Docker images.
 
 The core requirement is to have [Docker](https://docker.com) and [Docker Compose](https://docs.docker.com/compose/) installed
 on the system.  Once you have Docker and Docker Compose installed you will be
-able to install the workshop without any other dependencies.
+able to install and run the workshop without any other dependencies.
 
 More information on installing Docker can also be found [here](./docker).
 
@@ -48,15 +48,29 @@ and `docker-compose` commands are working and available:
 
 ```bash
 docker version
-docker-compose version
+docker-compose --version
 ```
+ 
+If `docker-compose` gives a 'program not found' error:
+
+> In recent versions of Docker the Docker Compose program is part
+> of the Docker CLI, thus following the `docker <cmd>` pattern. 
+> If `docker-compose --version` as above fails for you, 
+> try `docker compose version` (all spaces). If the latter command works
+> then use `docker compose` where the text shows `docker-compose`.
+> Note that our main Bash script `geopython-workshop-ctl.sh` (see below) will
+> figure out which variant you have installed and call the prober Docker Compose
+> command.
 
 ## Installation
+ 
+Below we will download and run the workshop content.
 
 ```bash
 curl -O https://codeload.github.com/geopython/geopython-workshop/zip/master
 unzip master
 cd geopython-workshop-master/workshop
+
 # start the workshop
 ./geopython-workshop-ctl.sh start
 
@@ -67,15 +81,29 @@ cd geopython-workshop-master/workshop
 ./geopython-workshop-ctl.sh stop
 ```
 
-If the above `.sh` scripts do not work on your system you can execute `docker-compose` directly via:
+If the above `.sh` script does not work on your system 
+you can execute `docker-compose` directly via:
 
 ```bash
 # in dir geopython-workshop-master/workshop
 docker-compose up -d
-docker logs geopython-workshop-jupyter
+docker logs --follow geopython-workshop-jupyter
 # look for URL+Token and Copy/Paste in browser
 ```
 
+Below are utility commands. Use when stopped to clean and update.
+
+```bash
+
+# update the workshop Docker Images in case of new versions
+./geopython-workshop-ctl.sh update
+
+# clean your Docker environment from dangling Images/Containers
+# (does not remove the workshop's images, only obsolete ones)
+./geopython-workshop-ctl.sh clean
+
+```
+ 
 ## Installation Issues
 
 Docker installed but problems installing/running the workshop? Below some tips:
@@ -83,7 +111,7 @@ Docker installed but problems installing/running the workshop? Below some tips:
 ### Download Problems
 
 Although `curl` may be on your system it may have problems with SSL (one user noted using OSGeo4W).
-In that case you can copy/paste the download URL in your browser and download from there.
+In that case you can add the `--insecure` commandline option or copy/paste the download URL in your browser and download from there.
 
 ### File/Drive Sharing
 
@@ -125,7 +153,7 @@ If you somehow were not able to install Docker:
 there is a Cloud version of the Jupyter-Notebook-part of the workshop via "Jupyter Binder".
 
 With some limits (e.g. no local geo-services, no data publication), 
-you may follow most of the workshop using a remote Docker instance within your 
+you can follow most of the workshop using a remote Docker instance within your 
 browser via "Jupyter Binder". Click on the button below
 to launch the Workshop Binder Instance. Startup takes a while, be patient...
 

--- a/workshop/geopython-workshop-ctl.sh
+++ b/workshop/geopython-workshop-ctl.sh
@@ -2,19 +2,40 @@
 
 PROGRAM_NAME=$(basename $0)
 
-USAGE="Usage: $PROGRAM_NAME <start|stop|url|clean>"
+USAGE="Usage: $PROGRAM_NAME <start|stop|url|update|clean>"
 
 if [ "$#" -ne 1 ]; then
     echo $USAGE
     exit 1
 fi
 
+alias dockercompose='docker-compose'
+
+# Sniff which Docker Compose variant is installed
+# and set an alias.
+# See https://github.com/geopython/geopython-workshop/issues/82
+if command docker-compose --version &> /dev/null
+then
+  alias dockercompose='docker-compose'
+  echo "Using docker-compose"
+else
+  if !command docker compose version &> /dev/null
+  then
+    echo "Neither dockercompose nor docker compose is installed"
+    echo "Check your Docker Installation"
+    exit 1
+  fi
+  alias dockercompose='docker compose'  
+  echo "Using docker compose"
+fi
+
+# Test for the command
 if [ $1 == "start" ]; then
     $0 stop
-    docker-compose up -d
+    dockercompose up -d
 elif [ $1 == "stop" ]; then
-    docker-compose stop
-    docker-compose rm --force
+    dockercompose stop
+    dockercompose rm --force
 elif [ $1 == "url" ]; then
     # try to open the Jupyter Notebook in Browser
     platform="$(uname | tr '[:upper:]' '[:lower:]')"
@@ -56,5 +77,5 @@ elif [ $1 == "clean" ]; then
         docker rmi ${i}
     done
 else
-    echo $USAGE
+    echo ${USAGE}
 fi

--- a/workshop/geopython-workshop-ctl.sh
+++ b/workshop/geopython-workshop-ctl.sh
@@ -19,7 +19,7 @@ then
 else
   if !command docker compose version &> /dev/null
   then
-    echo "Neither dockercompose nor docker compose is installed"
+    echo "Neither docker-compose nor docker compose is available"
     echo "Check your Docker Installation"
     exit 1
   fi

--- a/workshop/geopython-workshop-ctl.sh
+++ b/workshop/geopython-workshop-ctl.sh
@@ -9,8 +9,6 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-alias dockercompose='docker-compose'
-
 # Sniff which Docker Compose variant is installed
 # and set an alias.
 # See https://github.com/geopython/geopython-workshop/issues/82


### PR DESCRIPTION
This PR:

- adds a sniffing wrapper (alias) within the `geopython-workshop-ctl.sh` script for Docker Compose variants
- adds/updates all documentation related to Docker
