### PR TITLE
[WIP] remove shopt&alias to make it work on powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Docker-Volume-mounted. There is no need to build the Docker Image yourself (see 
 
 All services are started using a [Docker Compose file](https://github.com/geopython/geopython-workshop/blob/master/workshop/docker-compose.yml).
 
-Windows users; use [powershell](https://en.wikipedia.org/wiki/PowerShell) or [Linux Subsystem](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) to run below commands.
+Windows users; use [powershell](https://en.wikipedia.org/wiki/PowerShell) or [Linux Subsystem](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) to run below commands. On powershell, use the .ps.sh script and prepend with `bash`, eg. `bash ./geopython-workshop-ctl.ps.sh start`.
 
 ```bash
 cd workshop

--- a/workshop/geopython-workshop-ctl.ps.sh
+++ b/workshop/geopython-workshop-ctl.ps.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-shopt -s expand_aliases
-
 PROGRAM_NAME=$(basename $0)
 
 USAGE="Usage: $PROGRAM_NAME <start|stop|url|update|clean>"
@@ -11,31 +9,13 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-# Sniff which Docker Compose variant is installed
-# and set an alias.
-# See https://github.com/geopython/geopython-workshop/issues/82
-if command docker-compose --version &> /dev/null
-then
-  alias dockercompose='docker-compose'
-  echo "Using docker-compose"
-else
-  if !command docker compose version &> /dev/null
-  then
-    echo "Neither docker-compose nor docker compose is available"
-    echo "Check your Docker Installation"
-    exit 1
-  fi
-  alias dockercompose='docker compose'  
-  echo "Using docker compose"
-fi
-
 # Test for the command
 if [ $1 == "start" ]; then
     $0 stop
-    dockercompose up -d
+    docker compose up -d
 elif [ $1 == "stop" ]; then
-    dockercompose stop
-    dockercompose rm --force
+    docker compose stop
+    docker compose rm --force
 elif [ $1 == "url" ]; then
     # try to open the Jupyter Notebook in Browser
     platform="$(uname | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
PR to facilitate discussion on this topic

docker-compose was removed >1 year ago, i think we can assume all are migrated by now?

removing shopt and alias because it is not supported on powershell/windows



todo: update docs for windows:
syntax:  bash geopython-workshop-ctl.sh start|stop|url|update

- [x] works on powershell (windows+docker desktop)
- [x] works on ubuntu (WSL)