### PR TITLE
Closes #36

### DIFF
--- a/workshop/jupyter/content/notebooks/03-spatial-reference-systems.ipynb
+++ b/workshop/jupyter/content/notebooks/03-spatial-reference-systems.ipynb
@@ -22,7 +22,7 @@
     " 2. *Cartographic Projection* - a set of mathematical functions that translate locations in the surface of the *datum* into the Cartesian plane.\n",
     " \n",
     "The World Geodetic System (WGS 84) is a collection of *datums* maintained by the  National\n",
-    "Geospatial-Intelligence Agency (NGA) of the USA that approximate the surface of the Earth as a whole. Most GPS or GNSS receivers today report geographic coordinates (latitude and longitude) in reference to one of the WGS 84 *datums*. For global cartography the WGS 84 can be a convenient choice, but for local mapping a bespoke *datum* is  more appropriate in most circumstances. National surveys defined specific *datums* that closely suit their country or region."
+    "Geospatial Intelligence Agency (NGA) of the USA that approximate the surface of the Earth as a whole. Most GPS or GNSS receivers today report geographic coordinates (latitude and longitude) in reference to one of the WGS 84 *datums*. For global cartography the WGS 84 can be a convenient choice, but for local mapping a bespoke *datum* is  more appropriate in most circumstances. National surveys defined specific *datums* that closely suit their country or region."
    ]
   },
   {
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Marinus of Tyre and Mercator projections are the most popular today, however, none of them is suited for either local or global cartography (apart from navigation applications in the case of Mercator). It is always useful to spend some time identifying the most appropriate projection for the work at hand. Cartographic projections introduce errors as they flatten the curved surface of the Earth onto a plane. A balance must be struck between the accuracy of areas, shapes and angles. For global mapping, projections like [Mollweide's Homolographic](https://en.wikipedia.org/wiki/Mollweide_projection), [Eckert IV](https://en.wikipedia.org/wiki/Eckert_IV_projection) or [Goode's Homolosine](https://en.wikipedia.org/wiki/Goode_homolosine_projection) present interesting compromises. For local mapping, the [Stereographic](https://en.wikipedia.org/wiki/Stereographic_projection#Applications_to_other_disciplines), [Lambert's Azimutal Equal-Area](https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection) and [Gauss-Krüger](https://en.wikipedia.org/wiki/Transverse_Mercator_projection#Ellipsoidal_transverse_Mercator) are popular choices, but many more exist."
+    "The Equirectangular and Mercator projections are the most popular today, however, none of them is suited for either local or global cartography. It is always useful to spend some time identifying the most appropriate projection for the work at hand. Cartographic projections introduce errors as they flatten the curved surface of the Earth onto a plane. A balance must be struck between the accuracy of areas, shapes and angles. For global mapping, projections like [Mollweide's Homolographic](https://en.wikipedia.org/wiki/Mollweide_projection), [Eckert IV](https://en.wikipedia.org/wiki/Eckert_IV_projection) or [Goode's Homolosine](https://en.wikipedia.org/wiki/Goode_homolosine_projection) present interesting compromises. For local mapping, the [Stereographic](https://en.wikipedia.org/wiki/Stereographic_projection#Applications_to_other_disciplines), [Lambert's Azimutal Equal-Area](https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection) and [Gauss-Krüger](https://en.wikipedia.org/wiki/Transverse_Mercator_projection#Ellipsoidal_transverse_Mercator) (*aka* \"Transverse Mercator\") are popular choices, but many more exist."
    ]
   },
   {
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Always keep in mind one thing: no cartographic projection is able to preserve distances correctly. Therefore **avoid computing distances** in the Cartesian plane, as they will be wrong. In small study areas the error might be negligible, but at global or continental scales, even for large countries like Russia, distances computed on the Cartesian plane are significantly off. "
+    "Always keep in mind one thing: no cartographic projection is able to fully preserve distances correctly. Therefore **avoid computing distances** in the Cartesian plane, as they will be wrong. In small study areas the error might be negligible, but at global or continental scales, even for large countries like Russia, distances computed on the Cartesian plane are significantly off. "
    ]
   },
   {
@@ -61,9 +61,9 @@
    "source": [
     "### Python libraries\n",
     "\n",
-    "The [PROJ](https://proj.org) library is a cornerstone of FOSS4G that implements a large number of cartographic projections and most geodetic datums. The list of [cartographic projections implemented by PROJ](https://proj.org/operations/projections/index.html) is a good place to start exploring the different characteristic of each projection. [pyproj](https://pyproj4.github.io/pyproj/stable/) is the native Python interface to PROJ.\n",
+    "The [PROJ](https://proj.org) library is a cornerstone of FOSS4G, implementing a large number of cartographic projections and most geodetic datums. The list of [cartographic projections implemented by PROJ](https://proj.org/operations/projections/index.html) is a good place to start exploring the different characteristics of each projection. [pyproj](https://pyproj4.github.io/pyproj/stable/) is the native Python interface to PROJ.\n",
     "\n",
-    "In alternative, the GDAL/OGR Python API library includes a dedicated module to handle Spatial Reference Systems (SRS): [osgeo.osr](https://gdal.org/python/osgeo.osr-pysrc.html). It may also be convinient in certain cases."
+    "In alternative, the GDAL/OGR Python API library includes a dedicated module to handle Spatial Reference Systems (SRS): [osgeo.osr](https://gdal.org/python/osgeo.osr-pysrc.html). It may be convinient in certain cases."
    ]
   },
   {
@@ -72,7 +72,7 @@
    "source": [
     "### Create a new Coordinate Reference System object\n",
     "\n",
-    "In `pyproj` the concept of CRS is encapsulated in a class with same name `CRS`. An object of this class can be parametrised in different ways. The simplest is possibly with a [PROJ string](https://proj.org/usage/quickstart.html), a synthetic and expressive string with set of parameters. This is made with the static method `from_pro4`:"
+    "In `pyproj` the concept of CRS is encapsulated in a class with same name: `CRS`. An object of this class can be parametrised in different ways. The simplest is possibly with a [PROJ4 string](https://proj.org/usage/quickstart.html), a synthetic and expressive string with a set of parameters. This is made with the static method `from_pro4`:"
    ]
   },
   {
@@ -82,14 +82,15 @@
    "outputs": [],
    "source": [
     "from pyproj import CRS\n",
-    "hammer = CRS.from_proj4(\"+proj=hammer +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs +wktext\")"
+    "hammer = CRS.from_proj4(\"+proj=hammer +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs +wktext\")\n",
+    "hammer"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although simple, PROJ strings leave some room for ambiguity. A more formal and precise way to initialise a `SpatialReference` object is using an [OGC Well Known Text](https://www.opengeospatial.org/standards/wkt-crs) definition. This is far more verbose, but also more accurate. The following example initialises a new object with the geographic system based on the WGS 84 datum series:"
+    "Although simple, PROJ strings leave some room for ambiguity. A more formal and precise way to initialise a `CRS` object is using an [OGC Well Known Text](https://www.opengeospatial.org/standards/wkt-crs) (WKT) definition. This is far more verbose, but also more accurate. The following example initialises a new object with the geographic system based on the WGS 84 datum series:"
    ]
   },
   {
@@ -112,16 +113,17 @@
     "\t\tPRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],\n",
     "\t\tUNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],\n",
     "\t\tAUTHORITY[\"EPSG\",\"4326\"]\n",
-    "\t]''')"
+    "\t]''')\n",
+    "geographic"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that no projection was defined, this system is supposed to refer strictly to latitude and longitude. However, most GIS programmes interpret this SRS as including the Marinus of Tyre projection (beware of distance or area computations).\n",
+    "Note that no projection was defined, this system is supposed to refer strictly to latitude and longitude. However, most GIS programmes interpret this CRS as including the Equirectangular projection (beware of distance or area computations).\n",
     "\n",
-    "The [European Petroleum Survey Group (EPSG)](http://wiki.gis.com/wiki/index.php/European_Petroleum_Survey_Group) was a scientific body supporting the Petroluem & Gas industry in Europe. It developed an [extensive database](http://www.epsg.org/) of parameters and complete SRS definitions, that helped the industry standardise its cartographic processes. The EPSG assigned a unique numerical identifier to each entry in its database, which became rather handy to quickly refer to a specific, well defined, SRS. Most open source geospatial software support the EPSG identifiers as quick reference (some even enforce it). Tools such as [epsg.io](https://epsg.io) provide quick and easy verification of EPSG codes. PROJ and GDAL are no exceptions, and therefore `CRS` objects can too be initialised with an EPSG identifier:"
+    "The [European Petroleum Survey Group (EPSG)](http://wiki.gis.com/wiki/index.php/European_Petroleum_Survey_Group) was a scientific body supporting the Petroluem & Gas industry in Europe. It developed an [extensive database](http://www.epsg.org/) of parameters and complete SRS definitions, to help the industry standardise its cartographic processes. The EPSG assigned a unique numerical identifier to each entry in its database, which became rather handy to quickly refer to a specific, well defined, SRS. Most open source geospatial software support the EPSG identifiers as quick reference (some even enforce it). Tools such as [epsg.io](https://epsg.io) provide quick and easy verification of EPSG codes. PROJ and GDAL are no exceptions, and therefore `CRS` objects can too be initialised with an EPSG identifier:"
    ]
   },
   {
@@ -130,14 +132,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gauss_krueger_arg = CRS.from_epsg(22174)"
+    "gauss_krueger_arg = CRS.from_epsg(22174)\n",
+    "gauss_krueger_arg"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are other methods to initialise a `CRS` object, but these are the most common. There are also reverse methods, that export a `CRS` into different formats that are simple to read:"
+    "There are other methods to initialise a `CRS` object, but these are the most common. \n",
+    "\n",
+    "It is possible to export a `CRS` into different formats that are simple to read or use by other software. For intance, the `to_wkt` method produces a WKT string:"
    ]
   },
   {
@@ -146,7 +151,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gauss_krueger_arg.to_wkt()"
+    "print(gauss_krueger_arg.to_wkt(pretty=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally an example outputting the PROJ4 string. Note how `pyproj` informs on the possible loss of information using this method."
    ]
   },
   {
@@ -162,9 +174,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create and use SRS transformations\n",
+    "### Create and use CRS transformations\n",
     "\n",
-    "With the SRSs parametrised, it becomes possible to convert coordinates between different systems. In the `osr` module this is made with the `CoordinateTransformation` class. It is initialised with an input SRS and an output SRS. The following defines a transformation between geographic coordinates and the Argentinian SRS with the Gauss-Krüger projection: "
+    "With the CRSs parametrised, it becomes possible to convert coordinates between different systems. In `pyproj` this is made with the `Transformer` class. It is initialised with an input CRS and an output CRS. The following defines a transformation between geographic coordinates and the Argentinian CRS with the Gauss-Krüger projection: "
    ]
   },
   {
@@ -173,14 +185,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transformArgentina = osr.CoordinateTransformation(geographic, gauss_krueger_arg)"
+    "from pyproj import Transformer\n",
+    "transformArgentina = Transformer.from_crs(geographic, gauss_krueger_arg)\n",
+    "transformArgentina"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Puente de la Mujer* is one of the modern monuments in Buenos Aires. Relative to the latest WGS84 *datum* its coordinates are approximately 34.61º S and 58.37º W. Let us check its coordinates in the Argentinian system:"
+    "*Puente de la Mujer* is one of the modern monuments in Buenos Aires. Relative to the latest WGS84 *datum* its coordinates are approximately 34.61º S and 58.37º W. Let us check its coordinates in the Argentinian system using the `transform` method."
    ]
   },
   {
@@ -189,40 +203,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transformArgentina.TransformPoint(-34.61, -58.37) #latitude comes first"
+    "transformArgentina.transform(-34.61, -58.37) #latitude comes first"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the geographic coordinates Latitude comes first, but for the cartesian coordinates, it is Easting first (*xx* in Cartesian plane). The third value in the output is height, a standard output of the `TransformPoint` method. This method can also take height as a third input.\n",
+    "Recall from above that in most geographic CRSs (like the WGS84) Latitude comes first, but for the cartesian coordinates, it is Easting first (*xx* axis). \n",
     "\n",
-    "Question: the central meridian of this system is 2º east of Buenos Aires, so why is the easting coordinate so high?\n",
-    "\n",
-    "### Working with geometries\n",
-    "\n",
-    "In most cases work evolves around existing spatial objects. Conveniently, the `Geometry` class in the `osgeo.ogr` module provides a method named `Transform` that takes as argument a `CoordinateTransformation` object. The segment below exemplifies its use:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from osgeo import ogr\n",
-    "geo_point = ogr.Geometry(ogr.wkbPoint)\n",
-    "geo_point.AddPoint(-34.61, -58.37) #latitude comes first\n",
-    "geo_point.Transform(transformArgentina)\n",
-    "print(f'The point transformed: {geo_point.GetX()} {geo_point.GetY()}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note how the transformation modified the `Geometry` object itself."
+    "Question: the central meridian of this system is 2º east of Buenos Aires, so why is the easting coordinate so high?\n"
    ]
   },
   {
@@ -231,9 +221,9 @@
    "source": [
     "### Practical example\n",
     "\n",
-    "In many cases it is necessary to work with spatial data created by someone else. It is then important to clearly identify the SRS of such data to make sure it matches the SRS used in the analysis.\n",
+    "In many cases it is necessary to work with spatial data created by someone else. It is then important to clearly identify the SCRS of such data to make sure it matches the CRS used in the analysis.\n",
     "\n",
-    "The example below opens a dataset with the borders of Argentina and inspects its SRS. This type of data is detailed in the [Vector Data](04-vector-data.ipynb) section."
+    "The example below opens a dataset with the borders of Argentina and inspects its CRS. This type of data is detailed in the [Vector Data](04-vector-data.ipynb) section."
    ]
   },
   {
@@ -242,35 +232,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from shapely.geometry import Polygon\n",
-    "\n",
-    "driver = ogr.GetDriverByName('GPKG')\n",
-    "dataSource = driver.Open('../data/argentina.gpkg', 0)\n",
-    "layer = dataSource.GetLayer()\n",
-    "feature = layer.GetNextFeature()\n",
-    "ref = feature.GetGeometryRef()\n",
-    "ref.GetSpatialReference().ExportToProj4()"
+    "import fiona\n",
+    "src_borders = fiona.open('../data/argentina.gpkg')\n",
+    "src_borders.crs_wkt"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This dataset includes only geographic coordinates, referring to the WGS84 datum ensemble. The `longlat` parameter means that the [Marinus of Tyre projection](https://en.wikipedia.org/wiki/Marinus_of_Tyre) is applied when plotting the data or using it directly in spatial analysis.\n",
+    "This dataset includes only geographic coordinates, referring to the WGS84 datum ensemble. The `longlat` parameter means that the [Equirectangular projection](https://en.wikipedia.org/wiki/Equirectangular_projection) is applied when plotting the data or using it directly in spatial analysis. This projection is also known as \"Plate Carré\".\n",
     "\n",
-    "What does this mean in practice? The best way is to plot the data and see how it looks. A simple way of doing so is with the `matplotlib` library, essentially passing a collection of coordinate pairs to a X-Y plot."
+    "What does this mean in practice? The best way is to plot the data and see how it looks. A simple way of doing so is with the `matplotlib` library, essentially passing a collection of coordinate pairs to a X-Y plot. In this example the `shape` method from the `shapely` library is used to otain the coordinate pairs from the file opened above."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from matplotlib import pyplot as plt\n",
-    "import shapely.wkt\n",
+    "from shapely.geometry import shape\n",
     "\n",
-    "borders = shapely.wkt.loads(feature.GetGeometryRef().ExportToWkt())\n",
+    "feature = next(iter(src_borders))\n",
+    "borders = shape(feature[\"geometry\"])\n",
+    "\n",
     "x,y = borders.geoms[0].exterior.xy\n",
     "\n",
     "fig = plt.figure(1, dpi=90)\n",
@@ -278,14 +274,14 @@
     "ax = fig.add_subplot(111, aspect='equal') \n",
     "ax.plot(x, y, color='#6699cc', alpha=0.7,\n",
     "    linewidth=2, solid_capstyle='round', zorder=2)\n",
-    "ax.set_title('Argentina - Marinus of Tyre projection')"
+    "ax.set_title('Argentina - Equirectangular projection')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What if a different SRS is required for analysis? The `transformArgentina` can be used again, but first the order of coordinates tuples must be swapped to *(latitute, longitude)*. "
+    "What if a different CRS is required for analysis? The `transformArgentina` object can be used again, keeping in mind the correct axes order *(latitute, longitude)*. "
    ]
   },
   {
@@ -294,42 +290,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coords_lst = list(borders.geoms[0].exterior.coords)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lat_lon = []\n",
-    "for coord in coords_lst:\n",
-    "    lat_lon.append((coord[1], coord[0]))"
+    "coords_transf = transformArgentina.transform(y, x) # Latitude first"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `TransformPoints` can also be used to transform a list of coordinate pairs. It returns a list of tuples, that is converted to a set of lists (one per coordinate) with the `zip` method. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "borders_arg = transformArgentina.TransformPoints(lat_lon)\n",
-    "y,x,z = list(zip(*borders_arg))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "With the transformed coordinates in separate lists, `matplotlib` can be used again to visually inspect the outcome."
+    "`matplotlib` can be used again to visually inspect the outcome."
    ]
   },
   {
@@ -340,7 +308,7 @@
    "source": [
     "fig = plt.figure(1, dpi=90)\n",
     "ax = fig.add_subplot(111, aspect='equal')\n",
-    "ax.plot(x, y, color='#6699cc', alpha=0.7,\n",
+    "ax.plot(coords_transf[1], coords_transf[0], color='#6699cc', alpha=0.7,\n",
     "    linewidth=2, solid_capstyle='round', zorder=2)   \n",
     "ax.set_title('Argentina - Gauss-Krüger (datum POSGAR 2007)')"
    ]

--- a/workshop/jupyter/content/notebooks/03-spatial-reference-systems.ipynb
+++ b/workshop/jupyter/content/notebooks/03-spatial-reference-systems.ipynb
@@ -8,36 +8,71 @@
     "\n",
     "### Short Introduction\n",
     "\n",
-    "A Spatial Reference System (SRS) is a mathematical construct that is essential to the discipline of Geography. It has two important roles:\n",
+    "A Spatial Reference System (SRS) or Coordinate Reference System (CRS) is a mathematical construct that is essential to the discipline of Geography. It has two important roles:\n",
     " 1. identify unequivocally and with precision the location of a spatial object;\n",
-    " 2. accurately portray spatial objects in maps. \n",
-    "\n",
+    " 2. accurately portray spatial objects in maps. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "In its most basic form a SRS is composed by two elements:\n",
     " 1. *Datum* - a sphere or ellipsoid that approximates the shape of the Earth, positioned relative to the latter. \n",
     " 2. *Cartographic Projection* - a set of mathematical functions that translate locations in the surface of the *datum* into the Cartesian plane.\n",
     " \n",
     "The World Geodetic System (WGS 84) is a collection of *datums* maintained by the  National\n",
-    "Geospatial-Intelligence Agency (NGA) of the USA that approximate the surface of the Earth as a whole. Most GPS or GNSS receivers today report geographic coordinates (latitude and longitude) in reference to one of the WGS 84 *datums*. For global cartography the WGS 84 can be a convenient choice, but for local mapping a bespoke *datum* is  more appropriate in most circumstances. National surveys defined specific *datums* that closely suit their country or region.\n",
-    "\n",
+    "Geospatial-Intelligence Agency (NGA) of the USA that approximate the surface of the Earth as a whole. Most GPS or GNSS receivers today report geographic coordinates (latitude and longitude) in reference to one of the WGS 84 *datums*. For global cartography the WGS 84 can be a convenient choice, but for local mapping a bespoke *datum* is  more appropriate in most circumstances. National surveys defined specific *datums* that closely suit their country or region."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "![Geodesic Datum](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Gloabl_and_Regional_Ellipsoids.svg/640px-Gloabl_and_Regional_Ellipsoids.svg.png)\n",
-    "*Sketch of geodesic data positioned relative to the Earth's surface. Source: [Wikipaedia](https://en.wikipedia.org/wiki/Geodetic_datum).* \n",
-    "\n",
-    "The Marinus of Tyre and Mercator projections are the most popular today, however, none of them is suited for either local or global cartography (apart from navigation applications in the case of Mercator). It is always useful to spend some time identifying the most appropriate projection for the work at hand. Cartographic projections introduce errors as they flatten the curved surface of the Earth onto a plane. A balance must be struck between the accuracy of areas, shapes and angles. For global mapping, projections like [Mollweide's Homolographic](https://en.wikipedia.org/wiki/Mollweide_projection), [Eckert IV](https://en.wikipedia.org/wiki/Eckert_IV_projection) or [Goode's Homolosine](https://en.wikipedia.org/wiki/Goode_homolosine_projection) present interesting compromises. For local mapping, the [Stereographic](https://en.wikipedia.org/wiki/Stereographic_projection#Applications_to_other_disciplines), [Lambert's Azimutal Equal-Area](https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection) and [Gauss-Krüger](https://en.wikipedia.org/wiki/Transverse_Mercator_projection#Ellipsoidal_transverse_Mercator) are popular choices, but many more exist.\n",
-    "\n",
+    "*Sketch of geodesic datums positioned relative to the Earth's surface. Source: [Wikipaedia](https://en.wikipedia.org/wiki/Geodetic_datum).* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Marinus of Tyre and Mercator projections are the most popular today, however, none of them is suited for either local or global cartography (apart from navigation applications in the case of Mercator). It is always useful to spend some time identifying the most appropriate projection for the work at hand. Cartographic projections introduce errors as they flatten the curved surface of the Earth onto a plane. A balance must be struck between the accuracy of areas, shapes and angles. For global mapping, projections like [Mollweide's Homolographic](https://en.wikipedia.org/wiki/Mollweide_projection), [Eckert IV](https://en.wikipedia.org/wiki/Eckert_IV_projection) or [Goode's Homolosine](https://en.wikipedia.org/wiki/Goode_homolosine_projection) present interesting compromises. For local mapping, the [Stereographic](https://en.wikipedia.org/wiki/Stereographic_projection#Applications_to_other_disciplines), [Lambert's Azimutal Equal-Area](https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection) and [Gauss-Krüger](https://en.wikipedia.org/wiki/Transverse_Mercator_projection#Ellipsoidal_transverse_Mercator) are popular choices, but many more exist."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "![Map Projections](https://upload.wikimedia.org/wikipedia/commons/0/02/Kaardiprojektsiooni_klassid.gif)\n",
-    "*Visual examples of the transformations applied to the *datum* by simple map projections. Source: [Wikipaedia](https://en.wikipedia.org/wiki/Map_projection).*\n",
-    "\n",
-    "Always keep in mind one thing: no cartographic projection is able to preserve distances correctly. Therefore avoid computing distances in the Cartesian plane, as they will be wrong. In small study areas the error might be negligible, but at global or continental scales, even for large countries like Russia, distances computed on the Cartesian plane are significantly off. \n",
-    "\n",
+    "*Visual examples of the transformations applied to the *datum* by simple map projections. Source: [Wikipaedia](https://en.wikipedia.org/wiki/Map_projection).*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Always keep in mind one thing: no cartographic projection is able to preserve distances correctly. Therefore **avoid computing distances** in the Cartesian plane, as they will be wrong. In small study areas the error might be negligible, but at global or continental scales, even for large countries like Russia, distances computed on the Cartesian plane are significantly off. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Python libraries\n",
     "\n",
-    "The GDAL/OGR Python API library includes a dedicated module to handle Spatial Reference Systems (SRS): [osgeo.osr](https://gdal.org/python/osgeo.osr-pysrc.html). This module makes it rather simple to parametrise SRSs and transform coordinates between.\n",
+    "The [PROJ](https://proj.org) library is a cornerstone of FOSS4G that implements a large number of cartographic projections and most geodetic datums. The list of [cartographic projections implemented by PROJ](https://proj.org/operations/projections/index.html) is a good place to start exploring the different characteristic of each projection. [pyproj](https://pyproj4.github.io/pyproj/stable/) is the native Python interface to PROJ.\n",
     "\n",
-    "The [PROJ](https://proj.org) library is a cornerstone of FOSS4G that implements a large number of cartographic projections. GDAL supports most of the projections implemented by PROJ, therefore they are also available to the `osgeo.osr` module. The list of [cartographic projections implemented by PROJ](https://proj.org/operations/projections/index.html) is a good place to start exploring the different characteristic of each projection. \n",
+    "In alternative, the GDAL/OGR Python API library includes a dedicated module to handle Spatial Reference Systems (SRS): [osgeo.osr](https://gdal.org/python/osgeo.osr-pysrc.html). It may also be convinient in certain cases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a new Coordinate Reference System object\n",
     "\n",
-    "### Create a new Spatial Reference object\n",
-    "\n",
-    "In the `osr` module the concept of SRS is encapsulated in the `SpatialReference` class. A SRS can be parametrised with an object of this class in different ways. The simplest is possibly using a [PROJ string](https://proj.org/usage/quickstart.html), a synthetic and expressive set of parameters in a character string. This is made through the `ImportFromProj4`method:"
+    "In `pyproj` the concept of CRS is encapsulated in a class with same name `CRS`. An object of this class can be parametrised in different ways. The simplest is possibly with a [PROJ string](https://proj.org/usage/quickstart.html), a synthetic and expressive string with set of parameters. This is made with the static method `from_pro4`:"
    ]
   },
   {
@@ -46,9 +81,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from osgeo import osr\n",
-    "hammer = osr.SpatialReference()\n",
-    "hammer.ImportFromProj4(\"+proj=hammer +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs +wktext\")"
+    "from pyproj import CRS\n",
+    "hammer = CRS.from_proj4(\"+proj=hammer +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs +wktext\")"
    ]
   },
   {
@@ -64,8 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geographic = osr.SpatialReference()\n",
-    "geographic.ImportFromWkt(\n",
+    "geographic = CRS.from_wkt(\n",
     "\t'''GEOGCS[\n",
     "\t\t\"WGS 84\",\n",
     "\t\tDATUM[\n",
@@ -88,7 +121,7 @@
    "source": [
     "Note that no projection was defined, this system is supposed to refer strictly to latitude and longitude. However, most GIS programmes interpret this SRS as including the Marinus of Tyre projection (beware of distance or area computations).\n",
     "\n",
-    "The [European Petroleum Survey Group (EPSG)](http://wiki.gis.com/wiki/index.php/European_Petroleum_Survey_Group) was a scientific body supporting the Petroluem & Gas industry in Europe. It developed an [extensive database](http://www.epsg.org/) of parameters and complete SRS definitions, that helped the industry standardise its cartographic processes. The EPSG assigned a unique numerical identifier to each entry in its database, which became rather handy to quickly refer to a specific, well defined, SRS. Most open source geospatial software support the EPSG identifiers as quick reference (some even enforce it). Tools such as [epsg.io](https://epsg.io) provide quick and easy verification of EPSG codes. PROJ and GDAL are no exceptions, and therefore `SpatialReference` objects can too be initialised with an EPSG identifier:"
+    "The [European Petroleum Survey Group (EPSG)](http://wiki.gis.com/wiki/index.php/European_Petroleum_Survey_Group) was a scientific body supporting the Petroluem & Gas industry in Europe. It developed an [extensive database](http://www.epsg.org/) of parameters and complete SRS definitions, that helped the industry standardise its cartographic processes. The EPSG assigned a unique numerical identifier to each entry in its database, which became rather handy to quickly refer to a specific, well defined, SRS. Most open source geospatial software support the EPSG identifiers as quick reference (some even enforce it). Tools such as [epsg.io](https://epsg.io) provide quick and easy verification of EPSG codes. PROJ and GDAL are no exceptions, and therefore `CRS` objects can too be initialised with an EPSG identifier:"
    ]
   },
   {
@@ -97,15 +130,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gauss_krueger_arg = osr.SpatialReference()\n",
-    "gauss_krueger_arg.ImportFromEPSG(22174)"
+    "gauss_krueger_arg = CRS.from_epsg(22174)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are other methods to initialise a `SpatialReference` object, but these are the most common. There are also reverse methods, that export a `SpatialReference` into different formats that are simple to read:"
+    "There are other methods to initialise a `CRS` object, but these are the most common. There are also reverse methods, that export a `CRS` into different formats that are simple to read:"
    ]
   },
   {
@@ -114,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(gauss_krueger_arg.ExportToPrettyWkt())"
+    "gauss_krueger_arg.to_wkt()"
    ]
   },
   {
@@ -123,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gauss_krueger_arg.ExportToProj4()"
+    "gauss_krueger_arg.to_proj4()"
    ]
   },
   {
@@ -363,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Makes use of `pyproj` in place of `osr`
- Removes all references to `osgeo.ogr` to open vector files
- Simplifies text, including references to map projections