### PR TITLE
Add support for Windows users with no WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Docker-Volume-mounted. There is no need to build the Docker Image yourself (see 
 
 All services are started using a [Docker Compose file](https://github.com/geopython/geopython-workshop/blob/master/workshop/docker-compose.yml).
 
-Windows users; use [powershell](https://en.wikipedia.org/wiki/PowerShell) or [Linux Subsystem](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) to run below commands.
+Linux, macOS, or WSL:
 
 ```bash
 cd workshop
@@ -33,6 +33,18 @@ cd workshop
 
 # NB Possibly best if we add a frontend or use docs ("home") as entrypoint
 ./geopython-workshop-ctl.sh stop
+```
+
+Windows (Powershell or Command Prompt):
+
+```bat
+cd workshop
+
+.\win-geopython-workshop-ctl.bat start
+
+.\win-geopython-workshop-ctl.bat url
+
+.\win-geopython-workshop-ctl.bat stop
 ```
 
 NB [Jupyter notebook](https://en.wikipedia.org/wiki/Project_Jupyter) needs a **token**. The token is displayed in the jupyter container logs on startup:

--- a/workshop/win-geopython-workshop-ctl.bat
+++ b/workshop/win-geopython-workshop-ctl.bat
@@ -21,12 +21,12 @@ REM Sniff which Docker Compose variant is installed
 REM and set an alias.
 REM See https://github.com/geopython/geopython-workshop/issues/82
 docker-compose --version >NUL
-IF %ERRORLEVEL% EQU 0 (
+IF !ERRORLEVEL! EQU 0 (
     SET DOCKERCOMPOSE=docker-compose
     ECHO Using docker-compose
 ) ELSE (
     docker compose version >NUL
-    IF %ERRORLEVEL% NEQ 0 (
+    IF !ERRORLEVEL! NEQ 0 (
         ECHO Neither docker-compose nor docker compose is available
         ECHO Check your Docker Installation
         ENDLOCAL

--- a/workshop/win-geopython-workshop-ctl.bat
+++ b/workshop/win-geopython-workshop-ctl.bat
@@ -1,0 +1,71 @@
+@ECHO OFF
+
+SETLOCAL EnableDelayedExpansion
+
+SET "PROGRAM_NAME=%~nx0"
+
+SET "USAGE=Usage: %PROGRAM_NAME% ^<start^|stop^|url^|update^|clean^>"
+
+IF "%1"=="" (
+    ECHO %USAGE%
+    ENDLOCAL
+    EXIT /B 1
+)
+IF NOT "%2"=="" (
+    ECHO %USAGE%
+    ENDLOCAL
+    EXIT /B 1
+)
+
+REM Sniff which Docker Compose variant is installed
+REM and set an alias.
+REM See https://github.com/geopython/geopython-workshop/issues/82
+docker-compose --version >NUL
+IF %ERRORLEVEL% EQU 0 (
+    SET DOCKERCOMPOSE=docker-compose
+    ECHO Using docker-compose
+) ELSE (
+    docker compose version >NUL
+    IF %ERRORLEVEL% NEQ 0 (
+        ECHO Neither docker-compose nor docker compose is available
+        ECHO Check your Docker Installation
+        ENDLOCAL
+        EXIT /B 1
+    )
+    SET "DOCKERCOMPOSE=docker compose"
+    ECHO Using docker compose
+)
+
+REM Test for the command
+IF /I "%1"=="start" (
+    %PROGRAM_NAME% stop
+    %DOCKERCOMPOSE% up -d
+) ELSE ( IF /I "%1"=="stop" (
+    %DOCKERCOMPOSE% stop
+    %DOCKERCOMPOSE% rm --force
+) ELSE ( IF /I "%1"=="url" (
+    REM try to open the Jupyter Notebook in Browser
+    REM Filter the URL from the log output
+    powershell -Command "try { $url = (docker logs geopython-workshop-jupyter 2>&1 | Select-String -Pattern 'http://127\.0\.0\.1\S+token\S+')[-1].Matches[0].Value; Write-Output ('Attempting to open ' + $url + ' in your browser on platform Windows...') 'If this fails, simply copy/paste that URL in your browser'; start $url } catch { exit 2 }"
+    IF !ERRORLEVEL! NEQ 0 (
+        ECHO workshop not started
+        ECHO did you start the workshop? (i.e. %PROGRAM_NAME% start^)
+        ENDLOCAL
+        EXIT /B 2
+    )
+) ELSE ( IF /I "%1"=="update" (
+    docker pull geopython/geopython-workshop:latest
+    ECHO:
+    ECHO:
+    ECHO workshop is running the latest Docker images
+    ECHO If updates occured, then stop/start the workshop
+) ELSE ( IF /I "%1"=="clean" (
+    REM Remove all exited containers
+    FOR /F %%c IN ('docker ps -a -f status^=exited -q') DO docker rm %%c
+    REM And dangling images
+    FOR /F %%i IN ('docker images -f dangling^=true -q') DO docker rmi %%i
+) ELSE (
+    ECHO %USAGE%
+) ) ) ) )
+
+ENDLOCAL


### PR DESCRIPTION
Fixes #176.

Added `win-geopython-workshop-ctl.bat` for Windows users who have not installed WSL. It is as close to a direct translation of `geopython-workshop-ctl.sh` as I could manage; I believe I have tested all commands to function identically and have identical outputs as long as Docker is properly installed.

I have used Windows line terminators `\r\n`. Switching to Unix line terminators `\n` should be done with caution, but should be OK [as long as no `CALL` or `GOTO` operators are introduced](https://serverfault.com/a/795638).

Feel free to ping me if changes are made to `geopython-workshop-ctl.sh`.