### PR TITLE
counter clockwise coordinate order of polygons

### DIFF
--- a/workshop/jupyter/content/notebooks/02-geometry.ipynb
+++ b/workshop/jupyter/content/notebooks/02-geometry.ipynb
@@ -203,7 +203,7 @@
    "outputs": [],
    "source": [
     "from shapely.geometry import Polygon\n",
-    "polygon = Polygon([(0, 0), (3, 4), (3, 0)])\n",
+    "polygon = Polygon([(0, 0), (3, 0), (3, 4)])\n",
     "polygon"
    ]
   },
@@ -372,7 +372,7 @@
    },
    "outputs": [],
    "source": [
-    "polygon = Polygon([(0, 0), (3, 4), (3, 0)])\n",
+    "polygon = Polygon([(0, 0), (3, 0), (3, 4)])\n",
     "polygon.contains(Point(0.5, 0.5))"
    ]
   },
@@ -426,7 +426,7 @@
    },
    "outputs": [],
    "source": [
-    "polygon = Polygon([(1, 1), (1,2), (2,2), (2,1)])\n",
+    "polygon = Polygon([(1, 1), (2,1), (2,2), (1,2)])\n",
     "ls3 = LineString([(0, 0), (3,3)])\n",
     "print(polygon.intersection(ls3))"
    ]


### PR DESCRIPTION
for discussion, i think we should be strict on counter-clockwise coordinate order in polygons, seems shapely has some mechanisms to support both orders, but in general would be good to adopt counter-clockwise. what do you think?