### PR TITLE
update pygeometa MCF files (#224)

### DIFF
--- a/workshop/jupyter/content/data/countries.mcf.yml
+++ b/workshop/jupyter/content/data/countries.mcf.yml
@@ -1,13 +1,14 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: naturalearth-countries
     language: en
     charset: utf8
     hierarchylevel: dataset
-    datestamp: 2018-05-21
     dataseturi: https://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries
+    dates:
+        creation: 2018-05-21
 
 spatial:
     datatype: vector

--- a/workshop/jupyter/content/data/woudc-stations.mcf.yml
+++ b/workshop/jupyter/content/data/woudc-stations.mcf.yml
@@ -1,13 +1,14 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: woudc-stations
     language: en
     charset: utf8
     hierarchylevel: dataset
-    datestamp: 2019-08-10
     dataseturi: https://woudc.org/data/stations
+    dates:
+        creation: 2019-08-10
 
 spatial:
     datatype: vector

--- a/workshop/jupyter/content/notebooks/08-metadata.ipynb
+++ b/workshop/jupyter/content/notebooks/08-metadata.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat ../data/countries.yml"
+    "!cat ../data/countries.mcf.yml"
    ]
   },
   {
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pygeometa metadata validate ../data/countries.yml"
+    "!pygeometa metadata validate ../data/countries.mcf.yml"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pygeometa metadata generate ../data/countries.yml --schema iso19139 --output /tmp/countries.xml"
+    "!pygeometa metadata generate ../data/countries.mcf.yml --schema iso19139 --output /tmp/countries.xml"
    ]
   },
   {
@@ -144,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pygeometa metadata generate ../data/countries.yml --schema oarec-record"
+    "!pygeometa metadata generate ../data/countries.mcf.yml --schema oarec-record"
    ]
   },
   {
@@ -161,7 +161,7 @@
    "outputs": [],
    "source": [
     "from pygeometa.core import read_mcf\n",
-    "mdata = read_mcf('../data/countries.yml')\n",
+    "mdata = read_mcf('../data/countries.mcf.yml')\n",
     "mdata"
    ]
   },

--- a/workshop/jupyter/content/notebooks/09-publishing.ipynb
+++ b/workshop/jupyter/content/notebooks/09-publishing.ipynb
@@ -227,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pygeometa metadata generate ../data/woudc-stations.yml --schema iso19139 --output ../data/woudc-stations.xml"
+    "!pygeometa metadata generate ../data/woudc-stations.mcf.yml --schema iso19139 --output ../data/woudc-stations.xml"
    ]
   },
   {


### PR DESCRIPTION
This PR updates to the latest pygeometa MCF format as well as filename extention conventions.

Fixes #224 