### PR TITLE
explain _repr_svg and print wms/wfs responses directly

### DIFF
--- a/workshop/jupyter/content/notebooks/02-geometry.ipynb
+++ b/workshop/jupyter/content/notebooks/02-geometry.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Geometry\n",
     "\n",
-    "This lesson brings you a bit back to highschool math: (Euclidian) Geometry, \n",
+    "This lesson brings you a bit back to highschool math: ([Euclidian](https://en.wikipedia.org/wiki/Euclidean_geometry)) Geometry, \n",
     "hopefully with more fun as within (geo)spatial IT/GIS we usually deal with\n",
     "real-world objects (roads, lakes, forests, etc) abstracted as geometries.\n",
     "\n",
@@ -204,7 +204,31 @@
    "source": [
     "from shapely.geometry import Polygon\n",
     "polygon = Polygon([(0, 0), (3, 0), (3, 4)])\n",
-    "polygon"
+    "polygon",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Jupyter (IPython) benefits from Shapely's `geometry._repr_svg_()` method to render any shapely geometry as image.\n",
+    "Whenever you `log` the value of a shapely geometry, an image (svg) is rendered of the geometry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Explicit use of _repr_svg_() method\n",
+    "svg = polygon._repr_svg_()\n",
+    "print(svg)"
    ]
   },
   {

--- a/workshop/jupyter/content/notebooks/09-publishing.ipynb
+++ b/workshop/jupyter/content/notebooks/09-publishing.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Publishing\n",
     "\n",
-    "**NB This Section is optional and not included in the FOSS4G 2024 Workshop**\n",
+    "**NB This Section is optional and not included in the FOSS4G 2026 Workshop**\n",
     "\n",
     "It may still be valuable to follow if time left or at home. Mind that the service containers can only be run in a local (Docker)\n",
     "environment, i.e. not through the Workshop Binder version in the cloud.\n",
@@ -58,8 +58,7 @@
     "\n",
     "Here you will see 10 feature collections listed on the resulting webpage.  Feature collections are\n",
     "identified by the `\"itemType\": \"feature\"` in the collection definition in the JSON response.\n",
-    "\n",
-    "Now let's add the WOUDC station data to our pygeoapi instance.\n"
+    "\n"
    ]
   },
   {
@@ -116,7 +115,12 @@
     "# Get items (paged) in Lakes collection\n",
     "lakes = oa_feat.collection('lakes')\n",
     "lakes_query = oa_feat.collection_items('lakes')\n",
-    "lakes_query['features'][0]"
+    "# Plot first lake\n",
+    "lake = lakes_query['features'][0]\n",
+    "print(lake.get('properties').get('name'))\n",
+    "from shapely.geometry import shape\n",
+    "lakepolygon = shape(lake.get('geometry'))\n",
+    "lakepolygon"
    ]
   },
   {

--- a/workshop/jupyter/content/notebooks/10-remote-data.ipynb
+++ b/workshop/jupyter/content/notebooks/10-remote-data.ipynb
@@ -24,7 +24,7 @@
     "`OWSLib` enables you to connect to these services as \n",
     "a client, mainly to fetch and query data from them. \n",
     "Currently WMS, WFS, WCS, CSW, WPS, SOS, WMC and the more recent OGC APIs like \n",
-    "*OGC API - Features* (formerly called \"WFS version 3\") are supported.\n",
+    "*OGC API - Features* are supported.\n",
     "The list of supported services is growing. \n",
     "\n",
     "Documentation: https://owslib.readthedocs.io\n"
@@ -150,7 +150,14 @@
     "# Get items (paged) in Lakes collection\n",
     "lakes = oa_feat.collection('lakes')\n",
     "lakes_query = oa_feat.collection_items('lakes')\n",
-    "lakes_query['features'][0]"
+    "lakes_query['features'][0]\n",
+    "\n",
+    "# Plot first lake\n",
+    "lake = lakes_query['features'][0]\n",
+    "print(lake.get('properties').get('name'))\n",
+    "from shapely.geometry import shape\n",
+    "lakepolygon = shape(lake.get('geometry'))\n",
+    "lakepolygon"
    ]
   },
   {
@@ -258,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download and save the data (image)"
+    "Fetch and display the image via WMS"
    ]
   },
   {
@@ -278,30 +285,8 @@
     "    bbox=[1.0, 50.0, 10.0, 54.0],\n",
     "    format=\"image/png\")\n",
     "\n",
-    "save_fp = 'test/10-wms.png'\n",
-    "with open(save_fp, 'wb') as out:\n",
-    "\tout.write(img.read())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Display image in Notebook or view in browser via [this link](test/10-wms.png)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from IPython.display import Image\n",
-    "Image(filename=save_fp)"
+    "from IPython.display import Image, display\n",
+    "display(Image(data=img.read()))\n"
    ]
   },
   {
@@ -500,7 +485,20 @@
    },
    "outputs": [],
    "source": [
-    "response = wfs.getfeature(typename='ms:cities', bbox=(15.7500260759, 42.65, 19.59976, 45.2337767604))"
+    "response = wfs.getfeature(typename='ms:cities', bbox=(15.7500260759, 42.65, 19.59976, 45.2337767604))\n",
+    "data = response.read()\n",
+    "\n",
+    "# Parse the GML response as Shapely geometries\n",
+    "from io import BytesIO\n",
+    "from geopandas import read_file\n",
+    "gdf = read_file(BytesIO(data))\n",
+    "\n",
+    "# Combine the points in a MultiPoint\n",
+    "from shapely import MultiPoint\n",
+    "mpgeom = MultiPoint(list(gdf.geometry))\n",
+    "\n",
+    "# Plot the geometry\n",
+    "mpgeom" 
    ]
   },
   {
@@ -888,7 +886,7 @@
     "tags": []
    },
    "source": [
-    "Download data from selected layer and write to a file."
+    "Download data from selected layer and plot."
    ]
   },
   {
@@ -908,9 +906,19 @@
    "source": [
     "identifier = 'ge:boreholes_cores_rbins'\n",
     "features = boreholes_wfs.getfeature([identifier])\n",
+    "data = features.read()\n",
     "\n",
-    "with open('test/10-boreholes.gml', 'w', encoding='UTF-8') as out:\n",
-    "    out.write(str(features.read(), 'UTF-8'))"
+    "# Parse the GML response as Shapely geometries\n",
+    "from io import BytesIO\n",
+    "from geopandas import read_file\n",
+    "gdf = read_file(BytesIO(data))\n",
+    "\n",
+    "# Combine the points in a MultiPoint\n",
+    "from shapely import MultiPoint\n",
+    "mpgeom = MultiPoint(list(gdf.geometry))\n",
+    "\n",
+    "# Plot the geometry\n",
+    "mpgeom" 
    ]
   },
   {


### PR DESCRIPTION
this explains how ipython renders shapely geoms as svg
it also implements direct rendering of wms/wfs responses, instead of saving it to file and referring to the file

welcoming your thoughts

resolves #237 #235