### PR TITLE
restore pydeck example with timi data

### DIFF
--- a/workshop/jupyter/content/notebooks/07-visualization.ipynb
+++ b/workshop/jupyter/content/notebooks/07-visualization.ipynb
@@ -10,7 +10,8 @@
     "\n",
     "* [Folium](#Folium)\n",
     "* [ipyleaflet](#ipyleaflet)\n",
-    "* [Bokeh](#Bokeh)\n"
+    "* [Bokeh](#Bokeh)\n",
+    "* [pydeck](#pydeck)\n"
    ]
   },
   {
@@ -639,6 +640,79 @@
     "p.scatter(x='x', y='y', size=10, alpha=0.7, source=geo_source, color='lightblue', legend_label='Populated Places')\n",
     "\n",
     "show(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## pydeck\n",
+    "pydeck is a vizualisation library based on deck.gl, which facilitates 3D vizualisations\n",
+    "The example below, shows the distribution of hotels, restaurants and pubs in Timisoara as hexagons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pydeck as pdk\n",
+    "\n",
+    "# Load GeoJSON\n",
+    "with open(\"../data/poi-timis.geojson\") as f:\n",
+    "    geojson = json.load(f)\n",
+    "\n",
+    "# Extract coordinates for HexagonLayer\n",
+    "points = [\n",
+    "    feature[\"geometry\"][\"coordinates\"]\n",
+    "    for feature in geojson[\"features\"]\n",
+    "    if feature[\"geometry\"][\"type\"] == \"Point\"\n",
+    "]\n",
+    "\n",
+    "hex_layer = pdk.Layer(\n",
+    "    \"HexagonLayer\",\n",
+    "    data=points,\n",
+    "    get_position=\"-\",\n",
+    "    radius=100,          # meters\n",
+    "    elevation_scale=5,  # height scaling\n",
+    "    elevation_range=[0, 200],\n",
+    "    extruded=True,\n",
+    "    pickable=True,\n",
+    "    auto_highlight=True,\n",
+    "    coverage=1,\n",
+    "    color_range=[\n",
+    "        [255, 255, 204],  # low density\n",
+    "        [199, 233, 180],\n",
+    "        [127, 205, 187],\n",
+    "        [65, 182, 196],\n",
+    "        [44, 127, 184],\n",
+    "        [37, 52, 148],    # high density (dark)\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "view_state = pdk.ViewState(\n",
+    "    latitude=45.75,\n",
+    "    longitude=21.25,\n",
+    "    zoom=12,\n",
+    "    pitch=45,\n",
+    ")\n",
+    "\n",
+    "deck = pdk.Deck(\n",
+    "    layers=[hex_layer],\n",
+    "    initial_view_state=view_state,\n",
+    "    map_style=\"light\",\n",
+    "    tooltip={\n",
+    "        \"html\": \"<b>Points:</b> {elevationValue}\",\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "deck"
    ]
   },
   {


### PR DESCRIPTION
restored a pydeck example, but with timi data

as suggested in #109

<img width="528" height="329" alt="image" src="https://github.com/user-attachments/assets/0279f800-45e8-494e-b4d5-52ee524e975d" />
