### PR TITLE
Set up devcontainer to run workshop notebooks in Github Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker network inspect workshop_default >/dev/null 2>&1 || docker network create workshop_default && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
+  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
   "name": "GeoPython",
   "image": "geopython/geopython-workshop:latest",
   "forwardPorts": [8888],
-  "postStartCommand": "jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
+  "postStartCommand": "jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root --IdentityProvider.token=''"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,8 @@
   "service": "jupyter",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "forwardPorts": [8888, 5000, 8001],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
   "postStartCommand": "docker network create workshop_default || true && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "GeoPython",
-  "image": "geopython/geopython-workshop:latest",
-  "forwardPorts": [8888],
+  "dockerComposeFile": [
+    "../workshop/docker-compose.yml",
+    "../workshop/docker-compose-services.yml"
+  ],
+  "service": "jupyter",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "forwardPorts": [8888, 5000, 8001],
   "postStartCommand": "jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root --IdentityProvider.token=''"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,4 @@
 {
-  "name": "GeoPython",
-  "dockerComposeFile": [
-    "../workshop/docker-compose.yml",
-    "../workshop/docker-compose-services.yml"
-  ],
-  "service": "jupyter",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "forwardPorts": [8888, 5000, 8001],
-  "postStartCommand": "jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root --IdentityProvider.token=''"
+  "dockerComposeFile": "../workshop/docker-compose.yml",
+  "postStartCommand": "docker network create workshop_default || true && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "GeoPython",
+  "image": "geopython/geopython-workshop:latest"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,9 @@
   "dockerComposeFile": "../workshop/docker-compose.yml",
   "service": "jupyter",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "forwardPorts": [8888, 5000, 8001],
+  "forwardPorts": [8888, 8001],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "bash -lc 'echo Closing forwarded ports; for p in $(code --list-ports 2>/dev/null | grep 5000 || true); do echo closing $p; done; docker network inspect workshop_default >/dev/null 2>&1 || docker network create workshop_default && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
+  "postStartCommand": "docker network inspect workshop_default >/dev/null 2>&1 || docker network create workshop_default && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "name": "GeoPython",
   "image": "geopython/geopython-workshop:latest",
-  "forwardPorts": [8888]
+  "forwardPorts": [8888],
+  "postStartCommand": "jupyter lab --ip=0.0.0.0 --no-browser"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,8 @@
 {
+  "name": "GeoPython",
   "dockerComposeFile": "../workshop/docker-compose.yml",
+  "service": "jupyter",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "forwardPorts": [8888, 5000, 8001],
   "postStartCommand": "docker network create workshop_default || true && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker network inspect workshop_default >/dev/null 2>&1 || docker network create workshop_default && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
+  "postStartCommand": "bash -lc 'echo Closing forwarded ports; for p in $(code --list-ports 2>/dev/null | grep 5000 || true); do echo closing $p; done; docker network inspect workshop_default >/dev/null 2>&1 || docker network create workshop_default && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 {
   "name": "GeoPython",
-  "image": "geopython/geopython-workshop:latest"
+  "image": "geopython/geopython-workshop:latest",
+  "forwardPorts": [8888]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker network create workshop_default || true && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
+  "postStartCommand": "docker network inspect workshop_default >/dev/null 2>&1 || docker network create workshop_default && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
   "name": "GeoPython",
   "image": "geopython/geopython-workshop:latest",
   "forwardPorts": [8888],
-  "postStartCommand": "jupyter lab --ip=0.0.0.0 --no-browser"
+  "postStartCommand": "jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ cd content/notebooks
 jupyter notebook
 ```
 
+### Running from Github Codespaces
+
+You can also use Github Codespaces after forking the repository:
+<img width="719" height="248" alt="image" src="https://github.com/user-attachments/assets/aa467a75-9ab9-46a2-98d3-ca8c4c278481" />
+
+You will need to run ```jupyter server list``` in the Terminal to get your Jupyter token:
+<img width="1057" height="854" alt="image" src="https://github.com/user-attachments/assets/2cfa5e21-0cad-43f3-bcee-ff158d7f71ea" />
+
+Then you can open port 8888 in the browser:
+<img width="1181" height="853" alt="image" src="https://github.com/user-attachments/assets/5f3b5171-1771-47d3-a300-9c956d68dfd5" />
+
 ### Bugs and Issues
 
 All bugs, enhancements and issues are managed


### PR DESCRIPTION
This PR allows to run the workshop exercises without any manual setup, just by forking the repo and creating a Codespace from the individual Github account. Instructions are added to Readme.

This includes setup for docker-compose-services. If it's not needed, the devcontainer.json can be even simpler:

```
{
  "name": "GeoPython",
  "image": "geopython/geopython-workshop:latest",
  "forwardPorts": [8888],
  "postStartCommand": "jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
}
```