### PR TITLE
Add VS Code hint for Codespaces and preinstall Python/Jupyter extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,13 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  },
   "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/docker-compose-services.yml up -d && jupyter notebook --ip 0.0.0.0 --no-browser --port 8888 --allow-root"
 }

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ jupyter notebook
 
 ### Running from Github Codespaces
 
+> **Tip:** the simplest way to run the exercises is to open the Codespace in
+> VS Code (the default when you launch a Codespace) and run the notebooks from
+> the editor — select the Python kernel when prompted and run the cells. VS Code
+> talks to the kernel directly, so you can skip the Jupyter token and port-8888
+> steps described below.
+
 You can also use Github Codespaces after forking the repository:
 <img width="719" height="248" alt="image" src="https://github.com/user-attachments/assets/aa467a75-9ab9-46a2-98d3-ca8c4c278481" />
 

--- a/web/docs/index.md
+++ b/web/docs/index.md
@@ -214,6 +214,8 @@ If you somehow were not able to install Docker, or had trouble starting the work
 
 ### GitHub Codespaces
 
+**Tip:** the simplest way is to open the Codespace in VS Code (the default when you launch a Codespace) and run the notebooks directly from the editor — select the Python kernel when prompted and run the cells. VS Code talks to the kernel directly, so you can skip the Jupyter token steps below.
+
 To run this workshop via GitHub Codespaces, please complete the following steps:
 
 - Navigate to https://github.com/geopython/geopython-workshop


### PR DESCRIPTION
The [GitHub Codespaces](https://docs.github.com/en/codespaces) instructions (in both the README and the [published install page](https://geopython.github.io/geopython-workshop)) walk users through copying a Jupyter token and opening port 8888 in the browser.

When a Codespace opens in the default [VS Code](https://code.visualstudio.com) editor, you can skip all of that: just open a notebook, pick the Python kernel, and run the cells — VS Code talks to the kernel directly. This PR adds a short tip pointing to that simpler path, leaving the existing token/browser instructions in place as an alternative.

It also preinstalls the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) extensions via the devcontainer, so they are ready on first launch instead of being installed on demand when you open a notebook.