### PR TITLE
Docker GHA: add trigger to run on release publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,9 @@ on:
       - workshop/jupyter/requirements.txt
       - .github/workflows/docker.yml
 
+  release:
+    types: [published]
+
 jobs:
   # Single job to build Docker Image and push (master-branch only) to DockerHub
   build_push:


### PR DESCRIPTION
This PR adds the ability for the Docker action to trigger on a [release](https://github.com/geopython/geopython-workshop/releases) (in addition to pushing/PRing to specific files).